### PR TITLE
allow use a customer MetricRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,25 @@ Default config:
       address  : "org.swisspush.metrics"
     }
 
+With customer MetricRegistry:
+
+    SharedMetricRegistries.add(
+        "my-registry",
+        new MyMetricRegistry());
+    SharedMetricRegistries.setDefault("my-registry");
+
+Config: 
+
+    {
+      address  : "org.swisspush.metrics",
+      registryName  :  "my-registry"
+    }
+
+
 Deploy with:
 
     vertx.deployVerticle("org.swisspush.metrics.MetricsModule", deploymentOptions, handler) ;
+
 
 You should then be able to point jconsole (or jvisualvm with the jmx plugin) at the
 machine running this module and see stats appear as they are populated.

--- a/src/main/java/org/swisspush/metrics/MetricsModule.java
+++ b/src/main/java/org/swisspush/metrics/MetricsModule.java
@@ -48,7 +48,15 @@ public class MetricsModule extends AbstractVerticle implements Handler<Message<J
         logger.info("Starting MetricsModule");
         config = config();
         address = getOptionalStringConfig( "address", "org.swisspush.metrics" ) ;
+        String registryName = getOptionalStringConfig( "registryName", null ) ;
+
         metrics = new MetricRegistry() ;
+        if (registryName != null) {
+            MetricRegistry other = SharedMetricRegistries.add(registryName, metrics);
+            if (other != null) {
+                metrics = other;
+            }
+        }
         timers = new HashMap<>() ;
         gauges = new ConcurrentHashMap<>() ;
         JmxReporter.forRegistry( metrics ).build().start() ;


### PR DESCRIPTION
to use a customer MetricRegistry to override the usage of ExponentiallyDecayingReservoir which may cause the memory leak