### PR TITLE
keep mbean name as before

### DIFF
--- a/src/main/java/org/swisspush/metrics/MetricsModule.java
+++ b/src/main/java/org/swisspush/metrics/MetricsModule.java
@@ -59,9 +59,11 @@ public class MetricsModule extends AbstractVerticle implements Handler<Message<J
         }
         timers = new HashMap<>() ;
         gauges = new ConcurrentHashMap<>() ;
-        JmxReporter.forRegistry( metrics ).build().start() ;
+        JmxReporter.forRegistry( metrics )
+                .createsObjectNamesWith(new SimpleObjectNameFactory())
+                .build().start() ;
 
-        logger.info("Register consumer for event bus address '"+address+"'");
+        logger.info("Register consumer for event bus address '" + address + "'");
         vertx.eventBus().consumer( address, this ) ;
 
         startPromise.complete();

--- a/src/main/java/org/swisspush/metrics/SimpleObjectNameFactory.java
+++ b/src/main/java/org/swisspush/metrics/SimpleObjectNameFactory.java
@@ -1,0 +1,33 @@
+package org.swisspush.metrics;
+
+import com.codahale.metrics.jmx.ObjectNameFactory;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+/**
+ * keep the mbean name formated as io.dropwizard.metrics V 4.0.2
+ */
+public class SimpleObjectNameFactory implements ObjectNameFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleObjectNameFactory.class);
+
+    @Override
+    public ObjectName createName(String type, String domain, String name) {
+        try {
+            ObjectName objectName = new ObjectName(domain, "name", name);
+            if (objectName.isPattern()) {
+                objectName = new ObjectName(domain, "name", ObjectName.quote(name));
+            }
+            return objectName;
+        } catch (MalformedObjectNameException e) {
+            try {
+                return new ObjectName(domain, "name", ObjectName.quote(name));
+            } catch (MalformedObjectNameException e1) {
+                LOGGER.warn("Unable to register {} {}", type, name, e1);
+                throw new RuntimeException(e1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The new io.dropwizard.metrics version just add the type name into mBean name, broken existing metrics